### PR TITLE
Export org.sireum.aadl.osate.awas.util

### DIFF
--- a/org.sireum.aadl.osate.awas/META-INF/MANIFEST.MF
+++ b/org.sireum.aadl.osate.awas/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Bundle-ClassPath: .,
  bin/
 Import-Package: org.osate.ge.diagram,
  org.osate.pluginsupport
-Export-Package: org.sireum.awas.AADLBridge,
+Export-Package: org.sireum.aadl.osate.awas.util,
+ org.sireum.awas.AADLBridge,
  org.sireum.awas.AliranAman,
  org.sireum.awas.Stpa,
  org.sireum.awas.analysis,


### PR DESCRIPTION
AwasUtil is not visible right now, this change should fix that